### PR TITLE
fix AUTO_GENERATE_AVATAR_SIZES being ignored

### DIFF
--- a/avatar/conf.py
+++ b/avatar/conf.py
@@ -25,4 +25,4 @@ class AvatarConf(AppConf):
     AUTO_GENERATE_SIZES = (DEFAULT_SIZE,)
 
     def configure_auto_generate_sizes(self, value):
-        return getattr(settings, 'AUTO_GENERATE_AVATAR_SIZES') or value
+        return getattr(settings, 'AUTO_GENERATE_AVATAR_SIZES', None) or value

--- a/avatar/conf.py
+++ b/avatar/conf.py
@@ -24,6 +24,5 @@ class AvatarConf(AppConf):
     CLEANUP_DELETED = False
     AUTO_GENERATE_SIZES = (DEFAULT_SIZE,)
 
-    def configure_auto_generate_avatar_sizes(self, value):
-        return value or getattr(settings, 'AUTO_GENERATE_AVATAR_SIZES',
-                                (self.DEFAULT_SIZE,))
+    def configure_auto_generate_sizes(self, value):
+        return getattr(settings, 'AUTO_GENERATE_AVATAR_SIZES') or value


### PR DESCRIPTION
any value specified in settings.py for AUTO_GENERATE_AVATAR_SIZES was being ignored due to a naming typo, although I am not entirely sure if this is the way it was imagined to work, but it surely gets the correct value now. please review / change if I didn't get it right