### PR TITLE
Django allows @ for usernames, so the render_primary url pattern should also

### DIFF
--- a/avatar/urls.py
+++ b/avatar/urls.py
@@ -8,7 +8,7 @@ urlpatterns = patterns('avatar.views',
     url(r'^add/$', 'add', name='avatar_add'),
     url(r'^change/$', 'change', name='avatar_change'),
     url(r'^delete/$', 'delete', name='avatar_delete'),
-    url(r'^render_primary/(?P<user>[\w\d\.\-_]{3,30})/(?P<size>[\d]+)/$', 'render_primary', name='avatar_render_primary'),
+    url(r'^render_primary/(?P<user>[\w\d\@\.\-_]{3,30})/(?P<size>[\d]+)/$', 'render_primary', name='avatar_render_primary'),
     url(r'^list/(?P<username>[\+\w\@\.]+)/$', 'avatar_gallery', name='avatar_gallery'),
     url(r'^list/(?P<username>[\+\w\@\.]+)/(?P<id>[\d]+)/$', 'avatar', name='avatar'),
 )


### PR DESCRIPTION
We found this on a site where a user registered with an @ in their username, as the regex doesn't include @ (which is valid for django usernames) the URL didn't resolve for avatar_render_primary. 