### PR TITLE
Use https to gravatar url

### DIFF
--- a/avatar/conf.py
+++ b/avatar/conf.py
@@ -8,7 +8,7 @@ class AvatarConf(AppConf):
     DEFAULT_SIZE = 80
     RESIZE_METHOD = Image.ANTIALIAS
     STORAGE_DIR = 'avatars'
-    GRAVATAR_BASE_URL = 'http://www.gravatar.com/avatar/'
+    GRAVATAR_BASE_URL = 'https://www.gravatar.com/avatar/'
     GRAVATAR_BACKUP = True
     GRAVATAR_DEFAULT = None
     DEFAULT_URL = 'avatar/img/default.jpg'


### PR DESCRIPTION
It's better to default to https for gravatar urls, otherwise https sites will get a mixed content warning and avatar won't be displayed in most browsers.