### PR TITLE
Add Django 1.8+ style Meta app_label to Avatar model

### DIFF
--- a/avatar/models.py
+++ b/avatar/models.py
@@ -70,6 +70,9 @@ class Avatar(models.Model):
                                blank=True)
     date_uploaded = models.DateTimeField(default=now)
 
+    class Meta:
+        app_label = 'avatar'
+
     def __unicode__(self):
         return _(six.u('Avatar for %s')) % self.user
 


### PR DESCRIPTION
Add app_label to Avatar model in order to fix RemovedInDjango19Warning:

> RemovedInDjango19Warning: Model class avatar.models.Avatar doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.

